### PR TITLE
Remove duplicate prop entry and Fix Ims registration

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -403,7 +403,7 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.ims</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
+        <version>1.4</version>
         <interface>
             <name>IImsRadio</name>
             <instance>imsradio0</instance>

--- a/vendor.prop
+++ b/vendor.prop
@@ -212,7 +212,6 @@ ro.boot.wificountrycode=US
 # KRAB
 # ADDITIONAL VENDOR BUILD PROPERTIES
 #
-qemu.hw.mainkeys=0
 vendor.video.disable.ubwc=1
 dalvik.vm.heapgrowthlimit=256m
 dalvik.vm.heapstartsize=8m


### PR DESCRIPTION
qemu.hw.mainkeys was defined twice in vendor.prop. If values differ from other prop entries builds will fail.

Log would spam `Cannot find entry vendor.qti.hardware.radio.ims@1.4::IImsRadio/imsradio0 in either framework or device VINTF manifest` while attempting IMS registration.

Changing the version for `vendor.qti.hardware.radio.ims` in manifest.xml from `1.0` to `1.4` eliminated the error and allowed IMS registration to complete.